### PR TITLE
Make h3 headers din font

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -14,7 +14,7 @@
   font-style: normal;
 }
 
-h1, h2 {
+h1, h2, h3 {
   font-family: $myFont;
 }
 


### PR DESCRIPTION
h1, h2 is in `din` font and not h3. This looks weird. Applied the change to make docs have a better look