### PR TITLE
Use temporary ids for bitcoin and litecoin

### DIFF
--- a/docs/iov-name-service/clients/06-chain-ids.md
+++ b/docs/iov-name-service/clients/06-chain-ids.md
@@ -8,14 +8,14 @@ sidebar_label: Chain-Ids supported by the IOV Name Service
 
 |   Blockchain Name    |  Chain-ID                                  |
 | -------------        | -------------                              |
-| Bitcoin Mainnet      | bip122-000000000019d6689c085ae165831e93    |
+| Bitcoin Mainnet      | bip122-tmp-bitcoin                         |
 | Cosmos Hub Mainnet   | cosmos-cosmoshub-3                         |
 | Ethereum Mainnet     | ethereum-eip155-1                          |
 | IOV Mainnet          | iov-mainnet                                |
 | IrisNet Mainnet      | cosmos-irishub                             |
 | Kava Mainnet         | cosmos-kava-2                              |
 | Lisk Mainnet         | lisk-ed14889723                            |
-| Litecoin Mainnet     | bip122-12a765e31ffd4059bada1e25190f6e98    |
+| Litecoin Mainnet     | bip122-tmp-litecoin                        |
 | Terra Money Mainnet  | cosmos-columbus-3                          |
 
 ## You want to add another chain?


### PR DESCRIPTION
We're limited to 32 characters by https://github.com/iov-one/weave/blob/master/cmd/bnsd/x/username/model.go#L30.  We'll have to
augment https://github.com/iov-one/weave/blob/master/cmd/bnsd/app/datamigration.go#L264 to transform all the chain ids.  (Note that non-bip122 ids need a colon to be properly CAIP.)